### PR TITLE
Update point_pillars version

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -58,7 +58,7 @@ RUN pip install -r requirements.txt
 RUN jupyter labextension install jupyterlab-plotly
 
 # Install PointPillars Package
-RUN pip install git+https://github.com/ika-rwth-aachen/PointPillars.git@fix/ika-changes
+RUN pip install git+https://github.com/ika-rwth-aachen/PointPillars.git
 
 # Install TensorBoard Widget
 RUN pip install git+https://github.com/cliffwoolley/jupyter_tensorboard.git

--- a/section_2_sensor_data_processing/6_grid_mapping.ipynb
+++ b/section_2_sensor_data_processing/6_grid_mapping.ipynb
@@ -45,23 +45,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Install Dependencies\n",
-    "Our data pipeline uses a [modified version of the point_pillars package](https://github.com/ika-rwth-aachen/PointPillars) to structure 3D point clouds in pillars that are then processed by the neural network. This is described in the [original PointPillars publication](https://arxiv.org/abs/1812.05784). The following command will download, compile and install the package directly from the git repository."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "python"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "!pip uninstall point_pillars --yes\n",
-    "!rm -rf point_pillars\n",
-    "!pip install --force-reinstall git+https://github.com/ika-rwth-aachen/PointPillars.git"
+    "### Dependencies\n",
+    "Our data pipeline uses again the [modified version of the point_pillars package](https://github.com/ika-rwth-aachen/PointPillars) to structure 3D point clouds in pillars that are then processed by the neural network. This is described in the [original PointPillars publication](https://arxiv.org/abs/1812.05784). We already installed the `point_pillars` python package and setup everything within this notebook."
    ]
   },
   {
@@ -788,6 +773,18 @@
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
After https://github.com/ika-rwth-aachen/PointPillars/pull/3 this PR updates the point pillar version.

The additional installation guide from the `6_grid_mapping.ipynb` is removed